### PR TITLE
Validate template models

### DIFF
--- a/src/FaluSdk/Extensions/EnumExtensions.cs
+++ b/src/FaluSdk/Extensions/EnumExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Runtime.Serialization;
 
-namespace System.Collections.Generic
+namespace System
 {
     internal static class EnumExtensions
     {

--- a/src/FaluSdk/Extensions/EnumExtensions.cs
+++ b/src/FaluSdk/Extensions/EnumExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace System
@@ -7,10 +8,8 @@ namespace System
     {
         public static string GetEnumMemberAttrValueOrDefault<T>(this T enumVal) where T : Enum
         {
-            var memInfo = typeof(T).GetMember(enumVal.ToString());
-            var attr = memInfo.FirstOrDefault()?.GetCustomAttributes(false)
-                              .OfType<EnumMemberAttribute>()
-                              .FirstOrDefault();
+            var memInfo = typeof(T).GetMember(enumVal.ToString()).FirstOrDefault();
+            var attr = memInfo?.GetCustomAttribute<EnumMemberAttribute>(inherit: false);
 
             return attr?.Value ?? enumVal.ToString().ToLowerInvariant();
         }

--- a/src/FaluSdk/Extensions/TypeExtensions.cs
+++ b/src/FaluSdk/Extensions/TypeExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Linq;
+
+namespace System
+{
+    internal static class TypeExtensions
+    {
+        private static readonly Type[] otherPrimitives = new[] {
+            typeof(string),
+            typeof(decimal),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(TimeSpan),
+            typeof(Guid),
+        };
+
+        public static bool IsAllowedForMessageTemplateModel(this Type type)
+        {
+            if (type is null) throw new ArgumentNullException(nameof(type));
+
+            if (type.IsGenericType)
+            {
+                var gt = type.GetGenericTypeDefinition();
+                if (gt == typeof(Nullable<>))
+                {
+                    var gta = type.GenericTypeArguments[0];
+                    return IsAllowedForMessageTemplateModel(gta);
+                }
+            }
+
+            if (type.IsPrimitive || type.IsArray || otherPrimitives.Contains(type) || type.IsEnum) return false;
+            return !typeof(IEnumerable).IsAssignableFrom(type) || typeof(IDictionary).IsAssignableFrom(type);
+        }
+
+        public static void EnsureAllowedForMessageTemplateModel(this Type type)
+        {
+            if (type is null) throw new ArgumentNullException(nameof(type));
+
+            if (!type.IsAllowedForMessageTemplateModel())
+            {
+                throw new InvalidOperationException($"Type '{type.FullName}' is not allowed for a MessageTemplate model. Try a plain object of IDictionary<string, object>");
+            }
+        }
+    }
+}

--- a/src/FaluSdk/FaluClientOptions.cs
+++ b/src/FaluSdk/FaluClientOptions.cs
@@ -18,7 +18,7 @@ namespace Falu
         /// Serialization options.
         /// For internal-use only;
         /// </summary>
-        public JsonSerializerOptions SerializerOptions { get; } = CreateSerializerOptions();
+        internal JsonSerializerOptions SerializerOptions { get; } = CreateSerializerOptions();
 
         /// <summary>
         /// The API Key for authenticating requests to Falu servers.

--- a/src/FaluSdk/MessageTemplates/MessageTemplatesService.cs
+++ b/src/FaluSdk/MessageTemplates/MessageTemplatesService.cs
@@ -119,6 +119,8 @@ namespace Falu.MessageTemplates
         {
             if (template is null) throw new ArgumentNullException(nameof(template));
 
+            template.Model?.GetType().EnsureAllowedForMessageTemplateModel();
+
             var uri = new Uri(BaseAddress, "/v1/message_templates/validate");
             return await PostAsJsonAsync<MessageTemplateValidationResponse>(uri, template, options, cancellationToken).ConfigureAwait(false);
         }

--- a/src/FaluSdk/Messages/MessagesService.cs
+++ b/src/FaluSdk/Messages/MessagesService.cs
@@ -63,6 +63,7 @@ namespace Falu.Messages
                                                                          CancellationToken cancellationToken = default)
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
+            message.Template?.Model?.GetType().EnsureAllowedForMessageTemplateModel();
 
             var uri = new Uri(BaseAddress, "/v1/messages");
             return await PostAsJsonAsync<Message>(uri, message, options, cancellationToken).ConfigureAwait(false);
@@ -105,6 +106,11 @@ namespace Falu.Messages
             {
                 throw new ArgumentOutOfRangeException(paramName: nameof(messages),
                                                       message: "The service does not support more than 10,000 (10k) messages");
+            }
+
+            foreach(var m in messages)
+            {
+                m.Template?.Model?.GetType().EnsureAllowedForMessageTemplateModel();
             }
 
             var uri = new Uri(BaseAddress, "/v1/messages/bulk");

--- a/tests/FaluSdk.Tests/TypeExtensionsTests.cs
+++ b/tests/FaluSdk.Tests/TypeExtensionsTests.cs
@@ -1,0 +1,119 @@
+﻿using Falu.MessageTemplates;
+using System;
+using Xunit;
+
+namespace Falu.Tests
+{
+    public class TypeExtensionsTests
+    {
+        [Theory]
+        [InlineData(typeof(TestEnum), false)]
+        [InlineData(typeof(string), false)]
+        [InlineData(typeof(char), false)]
+        [InlineData(typeof(Guid), false)]
+
+        [InlineData(typeof(bool), false)]
+        [InlineData(typeof(byte), false)]
+        [InlineData(typeof(short), false)]
+        [InlineData(typeof(int), false)]
+        [InlineData(typeof(long), false)]
+        [InlineData(typeof(float), false)]
+        [InlineData(typeof(double), false)]
+        [InlineData(typeof(decimal), false)]
+
+        [InlineData(typeof(sbyte), false)]
+        [InlineData(typeof(ushort), false)]
+        [InlineData(typeof(uint), false)]
+        [InlineData(typeof(ulong), false)]
+
+        [InlineData(typeof(DateTime), false)]
+        [InlineData(typeof(DateTimeOffset), false)]
+        [InlineData(typeof(TimeSpan), false)]
+
+        [InlineData(typeof(TestStruct), true)]
+        [InlineData(typeof(TestClass1), true)]
+
+        [InlineData(typeof(TestEnum?), false)]
+        [InlineData(typeof(char?), false)]
+        [InlineData(typeof(Guid?), false)]
+
+        [InlineData(typeof(bool?), false)]
+        [InlineData(typeof(byte?), false)]
+        [InlineData(typeof(short?), false)]
+        [InlineData(typeof(int?), false)]
+        [InlineData(typeof(long?), false)]
+        [InlineData(typeof(float?), false)]
+        [InlineData(typeof(double?), false)]
+        [InlineData(typeof(decimal?), false)]
+
+        [InlineData(typeof(sbyte?), false)]
+        [InlineData(typeof(ushort?), false)]
+        [InlineData(typeof(uint?), false)]
+        [InlineData(typeof(ulong?), false)]
+
+        [InlineData(typeof(DateTime?), false)]
+        [InlineData(typeof(DateTimeOffset?), false)]
+        [InlineData(typeof(TimeSpan?), false)]
+
+        [InlineData(typeof(TestStruct?), true)]
+        public void Check_Works(Type type, bool expected)
+        {
+            var actual = type.IsAllowedForMessageTemplateModel();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Check_Throws_InvalidOperationException()
+        {
+            var n = new MessageTemplateValidationRequest
+            {
+                Body = "Cakes",
+                Model = DateTimeOffset.UtcNow,
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => n.Model?.GetType().EnsureAllowedForMessageTemplateModel());
+            var expected = "Type 'System.DateTimeOffset' is not allowed for a MessageTemplate model. Try a plain object of IDictionary<string, object>";
+            Assert.Equal(expected, ex.Message);
+        }
+
+        [Fact]
+        public void Check_Throws_InvalidOperationException_ForNullable()
+        {
+            var n = new MessageTemplateValidationRequest
+            {
+                Body = "Cakes",
+                Model = (DateTimeOffset?)DateTimeOffset.UtcNow,
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => n.Model?.GetType().EnsureAllowedForMessageTemplateModel());
+            var expected = "Type 'System.DateTimeOffset' is not allowed for a MessageTemplate model. Try a plain object of IDictionary<string, object>";
+            Assert.Equal(expected, ex.Message);
+        }
+
+        [Fact]
+        public void Check_DoesNotThrow()
+        {
+            var n = new MessageTemplateValidationRequest
+            {
+                Body = "Cakes",
+                Model = (DateTimeOffset?)null,
+            };
+
+            n.Model?.GetType().EnsureAllowedForMessageTemplateModel();
+        }
+
+        struct TestStruct
+        {
+            public string Prop1 { get; set; }
+            public int Prop2 { get; set; }
+        }
+
+        class TestClass1
+        {
+            public string? Prop1 { get; set; }
+            public int Prop2 { get; set; }
+        }
+
+        enum TestEnum { TheValue }
+    }
+}


### PR DESCRIPTION
In this PR:

- `FaliClientOptions.SerializerOptions` is now internal.
- Values set for `MessageTemplateValidationRequest.Model` and `MessageSourceTemplate.Model` are validated to ensure they are objects.