### PR TITLE
Remove configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ public void ConfigureServices(IServiceCollection services)
    // Add client
    services.AddFalu(Configuration["Falu:ApiKey"]);
 
-   //// You can also use whole configuration section
-   // services.AddFalu(Configuration.GetSection("Falu"));
-
    // The sample service we'll use to demonstrate usage
    // It is recommended the service be consumed in a service with scoped or transient lifetime and not in a singleton one
    // If you have to consume in a singleton service, inject an instance of IServiceProvider and get an instance from there when needed

--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -84,6 +84,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TClient : FaluClient<TClientOptions>
             where TClientOptions : FaluClientOptions
         {
+            /*
+             * Binding options from an IConfiguration instance is not used to reduce dependencies and leave that to the caller.
+             * Should the implementor/user require this, they can add it using:
+             * services.AddFalu(options => Configuration.GetSection("Falu").Bind(options));
+             */
+
             if (configure != null)
             {
                 services.Configure(configure);

--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Falu;
 using Falu.Core;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
@@ -46,25 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configure));
             }
 
-            return services.AddFalu(configuration: null, configure: configure, configureBuilder: null);
-        }
-
-        /// <summary>
-        /// Add client for Falu API
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection"/> to be added to.</param>
-        /// <param name="configuration">
-        /// An <see cref="IConfiguration"/> containing the values of <see cref="FaluClientOptions"/> at its root.
-        /// </param>
-        /// <returns></returns>
-        public static IServiceCollection AddFalu(this IServiceCollection services, IConfiguration configuration)
-        {
-            if (configuration is null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            return services.AddFalu(configuration: configuration, configure: null, configureBuilder: null);
+            return services.AddFalu(configure: configure, configureBuilder: null);
         }
 
         /// <summary>
@@ -78,12 +59,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configureBuilder">An <see cref="Action{IHttpClientBuilder}"/> to configure the HTTP client builder.</param>
         /// <returns></returns>
         public static IServiceCollection AddFalu(this IServiceCollection services,
-                                                 IConfiguration? configuration = null,
                                                  Action<FaluClientOptions>? configure = null,
                                                  Action<IHttpClientBuilder>? configureBuilder = null)
         {
-            return services.AddFalu<FaluClient, FaluClientOptions>(configuration: configuration,
-                                                                   configure: configure,
+            return services.AddFalu<FaluClient, FaluClientOptions>(configure: configure,
                                                                    configureBuilder: configureBuilder);
         }
 
@@ -100,17 +79,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configureBuilder">An <see cref="Action{IHttpClientBuilder}"/> to configure the HTTP client builder.</param>
         /// <returns></returns>
         public static IServiceCollection AddFalu<TClient, TClientOptions>(this IServiceCollection services,
-                                                                          IConfiguration? configuration = null,
                                                                           Action<TClientOptions>? configure = null,
                                                                           Action<IHttpClientBuilder>? configureBuilder = null)
             where TClient : FaluClient<TClientOptions>
             where TClientOptions : FaluClientOptions
         {
-            if (configuration is not null)
-            {
-                services.Configure<TClientOptions>(configuration);
-            }
-
             if (configure != null)
             {
                 services.Configure(configure);

--- a/src/FaluSdk/FaluSdk.csproj
+++ b/src/FaluSdk/FaluSdk.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Tingle.Extensions.JsonPatch" Version="3.4.4" />
   </ItemGroup>

--- a/tests/FaluSdk.Tests/FaluSdk.Tests.csproj
+++ b/tests/FaluSdk.Tests/FaluSdk.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
@@ -77,27 +77,5 @@ namespace Falu.Tests
             // Assert
             Assert.NotNull(client);
         }
-
-        [Fact]
-        public void TestAddFaluCanResolveFaluClientFromConfiguration()
-        {
-            // Arrange
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
-                    ["Falu:ApiKey"] = "FAKE_APIKEY",
-                    ["Falu:Retries"] = "0",
-                })
-                .Build();
-            var services = new ServiceCollection()
-                .AddFalu(configuration.GetSection("Falu"))
-                .BuildServiceProvider();
-
-            // Act
-            var client = services.GetService<FaluClient>();
-
-            // Assert
-            Assert.NotNull(client);
-        }
     }
 }

--- a/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,5 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 


### PR DESCRIPTION
This PR removes support for `IConfiguration` added earlier, primarily to reduce the number of dependencies. Should the implementor/user need similar functionality, it can be added using:

 ```cs
services.AddFalu(options => Configuration.GetSection("Falu").Bind(options));
```