### PR TITLE
Use IOptionsSnapshot

### DIFF
--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -89,9 +89,12 @@ namespace Microsoft.Extensions.DependencyInjection
                                   });
 
             // setup retries
-            builder.AddPolicyHandler((provider, request) =>
+            builder.AddPolicyHandler((sp, request) =>
             {
-                var options = provider.GetRequiredService<IOptions<TClientOptions>>().Value;
+                // Using scope otherwise the IOptionsSnapshot<T> instance will be singleton, never changing
+                using var scope = sp.CreateScope();
+                var provider = scope.ServiceProvider;
+                var options = provider.GetRequiredService<IOptionsSnapshot<TClientOptions>>().Value;
                 var delays = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: TimeSpan.FromSeconds(0.5f),
                                                                  retryCount: options.Retries);
 

--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -86,14 +86,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
                                       // populate the User-Agent value for the SDK/library
                                       client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("falu-dotnet", productVersion));
-
-                                      // populate the User-Agent for 3rd party providers
-                                      var options = provider.GetRequiredService<IOptions<TClientOptions>>().Value;
-                                      if (options.Application is not null)
-                                      {
-                                          var userAgent = options.Application.ToString();
-                                          client.DefaultRequestHeaders.Add("User-Agent", userAgent);
-                                      }
                                   });
 
             // setup retries

--- a/src/FaluSdk/FaluClient.cs
+++ b/src/FaluSdk/FaluClient.cs
@@ -28,7 +28,7 @@ namespace Falu
         /// </summary>
         /// <param name="backChannel"></param>
         /// <param name="optionsAccessor"></param>
-        public FaluClient(HttpClient backChannel, IOptions<TOptions> optionsAccessor)
+        public FaluClient(HttpClient backChannel, IOptionsSnapshot<TOptions> optionsAccessor)
         {
             BackChannel = backChannel ?? throw new ArgumentNullException(nameof(backChannel));
             Options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
@@ -116,6 +116,6 @@ namespace Falu
         /// </summary>
         /// <param name="backChannel"></param>
         /// <param name="optionsAccessor"></param>
-        public FaluClient(HttpClient backChannel, IOptions<FaluClientOptions> optionsAccessor) : base(backChannel, optionsAccessor) { }
+        public FaluClient(HttpClient backChannel, IOptionsSnapshot<FaluClientOptions> optionsAccessor) : base(backChannel, optionsAccessor) { }
     }
 }

--- a/src/FaluSdk/FaluClient.cs
+++ b/src/FaluSdk/FaluClient.cs
@@ -33,6 +33,14 @@ namespace Falu
             BackChannel = backChannel ?? throw new ArgumentNullException(nameof(backChannel));
             Options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
 
+
+            // populate the User-Agent for 3rd party providers
+            if (Options.Application is not null)
+            {
+                var userAgent = Options.Application.ToString();
+                BackChannel.DefaultRequestHeaders.Add("User-Agent", userAgent);
+            }
+
             Evaluations = new EvaluationsServiceClient(BackChannel, Options);
             Events = new EventsServiceClient(BackChannel, Options);
             Files = new FilesServiceClient(BackChannel, Options);

--- a/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
@@ -57,7 +57,7 @@ namespace Falu.Tests
             var provider = services.BuildServiceProvider();
 
             // Act
-            var options = provider.GetService<IOptions<FaluClientOptions>>();
+            var options = provider.GetService<IOptionsSnapshot<FaluClientOptions>>();
 
             // Assert
             Assert.NotNull(options);

--- a/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
@@ -49,21 +49,6 @@ namespace Falu.Tests
         }
 
         [Fact]
-        public void TestAddFaluCanResolveFaluClientOptions()
-        {
-            // Arrange
-            var services = new ServiceCollection();
-            services.AddFalu(options => options.ApiKey = "FAKE_APIKEY");
-            var provider = services.BuildServiceProvider();
-
-            // Act
-            var options = provider.GetService<IOptionsSnapshot<FaluClientOptions>>();
-
-            // Assert
-            Assert.NotNull(options);
-        }
-
-        [Fact]
         public void TestAddFaluCanResolveFaluClient()
         {
             // Arrange
@@ -76,6 +61,42 @@ namespace Falu.Tests
 
             // Assert
             Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void TestFaluClientOptionsAreTheSame()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddFalu(options => options.ApiKey = "FAKE_APIKEY");
+            var provider = services.BuildServiceProvider();
+
+            // Act
+            var options1 = provider.GetService<IOptionsSnapshot<FaluClientOptions>>();
+            var options2 = provider.GetService<IOptionsSnapshot<FaluClientOptions>>();
+
+            // Assert
+            Assert.Equal(options1, options2);
+        }
+
+        [Fact]
+        public void TestFaluClientOptionsAreDifferent()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddFalu(options => options.ApiKey = "FAKE_APIKEY");
+            var provider = services.BuildServiceProvider();
+
+            // Act
+            using var scope1 = provider.CreateScope();
+            var provider1 = scope1.ServiceProvider;
+            var options1 = provider1.GetService<IOptionsSnapshot<FaluClientOptions>>();
+            using var scope2 = provider.CreateScope();
+            var provider2 = scope2.ServiceProvider;
+            var options2 = provider2.GetService<IOptionsSnapshot<FaluClientOptions>>();
+
+            // Assert
+            Assert.NotEqual(options1, options2);
         }
     }
 }


### PR DESCRIPTION
This PR replaces the use of `IOptions<T>` with `IOptionsSnapshot<T>` which is better since the client registered using a transient lifetime.