### PR TITLE
List of values for query should be added as multiple entries not combined

### DIFF
--- a/src/FaluSdk/Core/QueryValues.cs
+++ b/src/FaluSdk/Core/QueryValues.cs
@@ -23,6 +23,17 @@ public sealed class QueryValues : IEnumerable<KeyValuePair<string, string[]>>
     public string[] this[string key] => values[key];
 
     ///
+    public QueryValues Add(string key, string[]? value)
+    {
+        if (value is not null)
+        {
+            values.Add(key, value);
+        }
+
+        return this;
+    }
+
+    ///
     public QueryValues Add(string key, string? value)
     {
         if (!string.IsNullOrWhiteSpace(value))

--- a/src/FaluSdk/Core/QueryValues.cs
+++ b/src/FaluSdk/Core/QueryValues.cs
@@ -5,29 +5,35 @@ using System.Text.Encodings.Web;
 namespace Falu.Core;
 
 /// <summary>Helper for handling query values.</summary>
-public sealed class QueryValues : IEnumerable<KeyValuePair<string, string>>
+public sealed class QueryValues : IEnumerable<KeyValuePair<string, string[]>>
 {
-    private readonly Dictionary<string, string> values;
+    private readonly Dictionary<string, string[]> values;
 
     ///
-    public QueryValues(Dictionary<string, string>? values = null)
+    public QueryValues(Dictionary<string, string[]>? values = null)
     {
         // keys are case insensitive
         this.values = values == null
-            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            : new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
+            ? new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string[]>(values, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>Gets or sets the value associated with the specified key.</summary>
     /// <param name="key">The key of the value to get or set.</param>
-    public string this[string key] => values[key];
+    public string[] this[string key] => values[key];
 
     ///
     public QueryValues Add(string key, string? value)
     {
         if (!string.IsNullOrWhiteSpace(value))
         {
-            values.Add(key, value);
+            var v = new[] { value, };
+            if (values.TryGetValue(key, out var value2))
+            {
+                values.Remove(key);
+                v = value2.Concat(v).ToArray();
+            }
+            values.Add(key, v);
         }
 
         return this;
@@ -58,7 +64,17 @@ public sealed class QueryValues : IEnumerable<KeyValuePair<string, string>>
     }
 
     ///
-    public QueryValues Add(string key, IEnumerable<string>? value) => Add(key, value is null ? null : string.Join(",", value));
+    public QueryValues Add(string key, IEnumerable<string>? value)
+    {
+        if (value is null) return this;
+
+        // for each item add a query parameter value, the server does not understand when combined
+        foreach (var item in value)
+        {
+            Add(key, item);
+        }
+        return this;
+    }
 
     ///
     public QueryValues Add(string property, QueryValues? other)
@@ -79,7 +95,7 @@ public sealed class QueryValues : IEnumerable<KeyValuePair<string, string>>
     }
 
     ///
-    internal Dictionary<string, string> ToDictionary() => values;
+    internal Dictionary<string, string[]> ToDictionary() => values;
 
     private string Generate()
     {
@@ -89,11 +105,16 @@ public sealed class QueryValues : IEnumerable<KeyValuePair<string, string>>
         {
             if (parameter.Value is null) continue;
 
-            builder.Append(first ? '?' : '&');
-            builder.Append(UrlEncoder.Default.Encode(parameter.Key));
-            builder.Append('=');
-            builder.Append(UrlEncoder.Default.Encode(parameter.Value));
-            first = false;
+            foreach (var value in parameter.Value)
+            {
+                if (value is null) continue;
+
+                builder.Append(first ? '?' : '&');
+                builder.Append(UrlEncoder.Default.Encode(parameter.Key));
+                builder.Append('=');
+                builder.Append(UrlEncoder.Default.Encode(value));
+                first = false;
+            }
         }
 
         return builder.ToString();
@@ -120,7 +141,7 @@ public sealed class QueryValues : IEnumerable<KeyValuePair<string, string>>
     #region IEnumerable
 
     /// <inheritdoc/>
-    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => values.GetEnumerator();
+    public IEnumerator<KeyValuePair<string, string[]>> GetEnumerator() => values.GetEnumerator();
 
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/FaluSdk/FaluClientOptions.cs
+++ b/src/FaluSdk/FaluClientOptions.cs
@@ -37,11 +37,9 @@ public class FaluClientOptions
     {
         if (serializerOptions is null)
         {
-            serializerOptions = new JsonSerializerOptions
+            serializerOptions = new(JsonSerializerDefaults.Web)
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true,
                 AllowTrailingCommas = true,
                 ReadCommentHandling = JsonCommentHandling.Skip,
             };

--- a/tests/FaluSdk.Tests/QueryValuesTests.cs
+++ b/tests/FaluSdk.Tests/QueryValuesTests.cs
@@ -44,7 +44,7 @@ public class QueryValuesTests
         var dictionary = query.ToDictionary();
         Assert.NotEmpty(dictionary);
         Assert.Equal(new[] { "sort", "count", "ct", }, dictionary.Keys);
-        Assert.Equal(new[] { "descending", "12", "123", }, dictionary.Values);
+        Assert.Equal(new[] { "descending", "12", "123", }, dictionary.Values.SelectMany(v => v));
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class QueryValuesTests
             "2021-03-11T19:41:25.0000000+03:00",
             "2021-03-10T16:41:25.0000000+00:00",
             "2021-03-10T19:41:25.0000000+03:00",
-        }, dictionary.Values);
+        }, dictionary.Values.SelectMany(v => v));
     }
 
     [Fact]
@@ -124,8 +124,9 @@ public class QueryValuesTests
             "descending",
             "12",
             "123",
-            "pending,closed",
+            "pending",
+            "closed",
             "false",
-        }, dictionary.Values);
+        }, dictionary.Values.SelectMany(v => v));
     }
 }

--- a/tests/FaluSdk.Tests/QueryValuesTests.cs
+++ b/tests/FaluSdk.Tests/QueryValuesTests.cs
@@ -1,5 +1,4 @@
 ﻿using Falu.Core;
-using Falu.Identity;
 using Falu.PaymentAuthorizations;
 using Xunit;
 


### PR DESCRIPTION
URLs with arrays in the query should repeat the `key=value` pattern for each entry as that's what the server expects.

The SDK previously generated an erroneous:
```
/v1/events?sort=desc&count=100&type=evaluation.created,evaluation.failed,evaluation.completed,money_balances.updated,payment.updated
```

This should change to:
```
/v1/events?sort=desc&count=100&type=evaluation.created&type=evaluation.failed&type=evaluation.completed&type=money_balances.updated&type=payment.updated
```