### PR TITLE
API updates

### DIFF
--- a/src/FaluSdk/Core/BaseServiceClientOfT.cs
+++ b/src/FaluSdk/Core/BaseServiceClientOfT.cs
@@ -81,6 +81,24 @@ public abstract class BaseServiceClient<TResource> : BaseServiceClient
 
 
     ///
+    protected virtual Task<ResourceResponse<TResource>> CancelResourceAsync(string id,
+                                                                            RequestOptions? options = null,
+                                                                            CancellationToken cancellationToken = default)
+    {
+        var uri = $"{MakeResourcePath(id)}/cancel";
+        return RequestAsync<TResource>(uri, HttpMethod.Post, null, options, cancellationToken);
+    }
+
+    ///
+    protected virtual Task<ResourceResponse<TResource>> RedactResourceAsync(string id,
+                                                                            RequestOptions? options = null,
+                                                                            CancellationToken cancellationToken = default)
+    {
+        var uri = $"{MakeResourcePath(id)}/redact";
+        return RequestAsync<TResource>(uri, HttpMethod.Post, null, options, cancellationToken);
+    }
+
+    ///
     protected virtual Task<ResourceResponse<object>> DeleteResourceAsync(string id,
                                                                          RequestOptions? options = null,
                                                                          CancellationToken cancellationToken = default)

--- a/src/FaluSdk/Core/ISupportsCanceling.cs
+++ b/src/FaluSdk/Core/ISupportsCanceling.cs
@@ -1,0 +1,16 @@
+﻿namespace Falu.Core;
+
+///
+public interface ISupportsCanceling<TResource> where TResource : IHasId, IHasRedaction
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="id">Unique identifier for the object.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<ResourceResponse<TResource>> CancelAsync(string id,
+                                                  RequestOptions? options = null,
+                                                  CancellationToken cancellationToken = default);
+}

--- a/src/FaluSdk/Evaluations/EvaluationsServiceClient.cs
+++ b/src/FaluSdk/Evaluations/EvaluationsServiceClient.cs
@@ -9,6 +9,7 @@ public class EvaluationsServiceClient : BaseServiceClient<Evaluation>,
                                         ISupportsRetrieving<Evaluation>,
                                         ISupportsCreation<Evaluation, EvaluationCreateRequest>,
                                         ISupportsUpdating<Evaluation, EvaluationPatchModel>,
+                                        ISupportsCanceling<Evaluation>,
                                         ISupportsRedaction<Evaluation>
 {
     ///
@@ -77,6 +78,19 @@ public class EvaluationsServiceClient : BaseServiceClient<Evaluation>,
                                                                   CancellationToken cancellationToken = default)
     {
         return CreateResourceAsync(request, options, cancellationToken);
+    }
+
+    /// <summary>Cancel an evaluation preventing further updates.</summary>
+    /// <param name="id">Unique identifier for the evaluation.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<ResourceResponse<Evaluation>> CancelAsync(string id,
+                                                          RequestOptions? options = null,
+                                                          CancellationToken cancellationToken = default)
+    {
+        var uri = $"{MakeResourcePath(id)}/cancel";
+        return RequestAsync<Evaluation>(uri, HttpMethod.Post, new { }, options, cancellationToken);
     }
 
     /// <summary>Redact an evaluation to remove all collected information from Falu.</summary>

--- a/src/FaluSdk/Evaluations/EvaluationsServiceClient.cs
+++ b/src/FaluSdk/Evaluations/EvaluationsServiceClient.cs
@@ -89,8 +89,7 @@ public class EvaluationsServiceClient : BaseServiceClient<Evaluation>,
                                                           RequestOptions? options = null,
                                                           CancellationToken cancellationToken = default)
     {
-        var uri = $"{MakeResourcePath(id)}/cancel";
-        return RequestAsync<Evaluation>(uri, HttpMethod.Post, new { }, options, cancellationToken);
+        return CancelResourceAsync(id, options, cancellationToken);
     }
 
     /// <summary>Redact an evaluation to remove all collected information from Falu.</summary>
@@ -102,7 +101,6 @@ public class EvaluationsServiceClient : BaseServiceClient<Evaluation>,
                                                           RequestOptions? options = null,
                                                           CancellationToken cancellationToken = default)
     {
-        var uri = $"{MakeResourcePath(id)}/redact";
-        return RequestAsync<Evaluation>(uri, HttpMethod.Post, new { }, options, cancellationToken);
+        return RedactResourceAsync(id, options, cancellationToken);
     }
 }

--- a/src/FaluSdk/FaluClient.cs
+++ b/src/FaluSdk/FaluClient.cs
@@ -6,6 +6,7 @@ using Falu.Files;
 using Falu.Identity;
 using Falu.IdentityVerificationReports;
 using Falu.IdentityVerifications;
+using Falu.MessageBatches;
 using Falu.Messages;
 using Falu.MessageStreams;
 using Falu.MessageTemplates;
@@ -53,6 +54,7 @@ public class FaluClient<TOptions> where TOptions : FaluClientOptions
         IdentityVerifications = new IdentityVerificationsServiceClient(BackChannel, Options);
         IdentityVerificationReports = new IdentityVerificationReportsServiceClient(BackChannel, Options);
         Messages = new MessagesServiceClient(BackChannel, Options);
+        MessageBatches = new MessageBatchesServiceClient(BackChannel, Options);
         MessageStreams = new MessageStreamsServiceClient(BackChannel, Options);
         MessageTemplates = new MessageTemplatesServiceClient(BackChannel, Options);
         MoneyBalances = new MoneyBalancesServiceClient(BackChannel, Options);
@@ -99,6 +101,9 @@ public class FaluClient<TOptions> where TOptions : FaluClientOptions
 
     ///
     public virtual MessagesServiceClient Messages { get; protected set; }
+
+    ///
+    public virtual MessageBatchesServiceClient MessageBatches { get; protected set; }
 
     ///
     public virtual MessageStreamsServiceClient MessageStreams { get; protected set; }

--- a/src/FaluSdk/IdentityVerifications/IdentityVerificationsServiceClient.cs
+++ b/src/FaluSdk/IdentityVerifications/IdentityVerificationsServiceClient.cs
@@ -5,11 +5,12 @@ namespace Falu.IdentityVerifications;
 
 ///
 public class IdentityVerificationsServiceClient : BaseServiceClient<IdentityVerification>,
-                                                   ISupportsListing<IdentityVerification, IdentityVerificationsListOptions>,
-                                                   ISupportsRetrieving<IdentityVerification>,
-                                                   ISupportsCreation<IdentityVerification, IdentityVerificationCreateRequest>,
-                                                   ISupportsUpdating<IdentityVerification, IdentityVerificationPatchModel>,
-                                                   ISupportsRedaction<IdentityVerification>
+                                                  ISupportsListing<IdentityVerification, IdentityVerificationsListOptions>,
+                                                  ISupportsRetrieving<IdentityVerification>,
+                                                  ISupportsCreation<IdentityVerification, IdentityVerificationCreateRequest>,
+                                                  ISupportsUpdating<IdentityVerification, IdentityVerificationPatchModel>,
+                                                  ISupportsCanceling<IdentityVerification>,
+                                                  ISupportsRedaction<IdentityVerification>
 {
     ///
     public IdentityVerificationsServiceClient(HttpClient backChannel, FaluClientOptions options) : base(backChannel, options) { }
@@ -77,6 +78,19 @@ public class IdentityVerificationsServiceClient : BaseServiceClient<IdentityVeri
                                                                             CancellationToken cancellationToken = default)
     {
         return CreateResourceAsync(request, options, cancellationToken);
+    }
+
+    /// <summary>Cancel an identity verification preventing further updates.</summary>
+    /// <param name="id">Unique identifier for the identity verification.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<ResourceResponse<IdentityVerification>> CancelAsync(string id,
+                                                                    RequestOptions? options = null,
+                                                                    CancellationToken cancellationToken = default)
+    {
+        var uri = $"{MakeResourcePath(id)}/cancel";
+        return RequestAsync<IdentityVerification>(uri, HttpMethod.Post, new { }, options, cancellationToken);
     }
 
     /// <summary>Redact an identity verification to remove all collected information from Falu.</summary>

--- a/src/FaluSdk/IdentityVerifications/IdentityVerificationsServiceClient.cs
+++ b/src/FaluSdk/IdentityVerifications/IdentityVerificationsServiceClient.cs
@@ -89,8 +89,7 @@ public class IdentityVerificationsServiceClient : BaseServiceClient<IdentityVeri
                                                                     RequestOptions? options = null,
                                                                     CancellationToken cancellationToken = default)
     {
-        var uri = $"{MakeResourcePath(id)}/cancel";
-        return RequestAsync<IdentityVerification>(uri, HttpMethod.Post, new { }, options, cancellationToken);
+        return CancelResourceAsync(id, options, cancellationToken);
     }
 
     /// <summary>Redact an identity verification to remove all collected information from Falu.</summary>
@@ -102,7 +101,6 @@ public class IdentityVerificationsServiceClient : BaseServiceClient<IdentityVeri
                                                                     RequestOptions? options = null,
                                                                     CancellationToken cancellationToken = default)
     {
-        var uri = $"{MakeResourcePath(id)}/redact";
-        return RequestAsync<IdentityVerification>(uri, HttpMethod.Post, new { }, options, cancellationToken);
+        return RedactResourceAsync(id, options, cancellationToken);
     }
 }

--- a/src/FaluSdk/MessageBatches/MessageBatch.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatch.cs
@@ -1,0 +1,50 @@
+﻿using Falu.Core;
+
+namespace Falu.MessageBatches;
+
+/// <summary>
+/// Represents a batch of messages
+/// </summary>
+public class MessageBatch : MessageBatchPatchModel, IHasId, IHasCreated, IHasUpdated, IHasRedaction, IHasWorkspace, IHasLive, IHasEtag
+{
+    /// <inheritdoc/>
+    public string? Id { get; set; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset Created { get; set; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset Updated { get; set; }
+
+    /// <summary>
+    /// Stream used for the message.
+    /// </summary>
+    public string? Stream { get; set; }
+
+    /// <summary>
+    /// Schedule information for the message batch.
+    /// </summary>
+    public MessageBatchSchedule? Schedule { get; set; }
+
+    /// <summary>
+    /// Unique identifiers of the messages tracked in this batch.
+    /// </summary>
+    public List<string>? Messages { get; set; }
+
+    /// <summary>
+    /// Total number of segments from each message.
+    /// </summary>
+    public int Segements { get; set; }
+
+    /// <inheritdoc/>
+    public DataRedaction? Redaction { get; set; }
+
+    /// <inheritdoc/>
+    public string? Workspace { get; set; }
+
+    /// <inheritdoc/>
+    public bool Live { get; set; }
+
+    /// <inheritdoc/>
+    public string? Etag { get; set; }
+}

--- a/src/FaluSdk/MessageBatches/MessageBatchCreateRequest.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchCreateRequest.cs
@@ -1,0 +1,28 @@
+﻿using Falu.Messages;
+
+namespace Falu.MessageBatches;
+
+/// <summary>
+/// Information for creating a message batch.
+/// </summary>
+public class MessageBatchCreateRequest
+{
+    /// <summary>
+    /// The messages.
+    /// </summary>
+    public List<MessageBatchCreateRequestMessage>? Messages { get; set; }
+
+    /// <summary>
+    /// The stream to use.
+    /// It can either be the name or unique identifier of the stream.
+    /// If not provided, message will default to the "transactional" stream.
+    /// </summary>
+    public string Stream { get; set; } = "transactional";
+
+    /// <summary>
+    /// Schedule for sending the message batch.
+    /// When <see langword="null"/>, the message batch
+    /// is enqueued for immediate sending.
+    /// </summary>
+    public MessageCreateRequestSchedule? Schedule { get; set; }
+}

--- a/src/FaluSdk/MessageBatches/MessageBatchCreateRequestMessage.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchCreateRequestMessage.cs
@@ -1,0 +1,27 @@
+﻿using Falu.Messages;
+
+namespace Falu.MessageBatches;
+
+/// <summary>
+/// Information about one or more messages to be created in a batch
+/// </summary>
+public class MessageBatchCreateRequestMessage
+{
+    /// <summary>
+    /// Destination phone numbers in <see href="https://en.wikipedia.org/wiki/E.164">E.164 format</see>.
+    /// You can provide up to 500 numbers in one request.
+    /// </summary>
+    public IList<string>? To { get; set; }
+
+    /// <summary>
+    /// Actual message content to be sent.
+    /// Required if <see cref="Template"/> is not specified.
+    /// </summary>
+    public string? Body { get; set; }
+
+    /// <summary>
+    /// The template to use.
+    /// Required if <see cref="Body"/> is not specified.
+    /// </summary>
+    public MessageSourceTemplate? Template { get; set; }
+}

--- a/src/FaluSdk/MessageBatches/MessageBatchPatchModel.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchPatchModel.cs
@@ -1,0 +1,12 @@
+﻿using Falu.Core;
+
+namespace Falu.MessageBatches;
+
+/// <summary>
+/// A model representing details that can be changed about a message batch.
+/// </summary>
+public class MessageBatchPatchModel : IHasMetadata
+{
+    /// <inheritdoc/>
+    public Dictionary<string, string>? Metadata { get; set; }
+}

--- a/src/FaluSdk/MessageBatches/MessageBatchSchedule.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchSchedule.cs
@@ -1,0 +1,17 @@
+﻿namespace Falu.MessageBatches;
+
+/// <summary>
+/// Information about scheduling for a message batch.
+/// </summary>
+public class MessageBatchSchedule
+{
+    /// <summary>
+    /// Time at which the message batch is/was scheduled scheduled to be sent.
+    /// </summary>
+    public DateTimeOffset Time { get; set; }
+
+    /// <summary>
+    /// Duration for which the message batch is/was to be delayed before sending.
+    /// </summary>
+    public TimeSpan? Delay { get; set; }
+}

--- a/src/FaluSdk/MessageBatches/MessageBatchesListOptions.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchesListOptions.cs
@@ -1,0 +1,19 @@
+﻿using Falu.Core;
+
+namespace Falu.MessageBatches;
+
+/// <summary>Options for filtering and pagination of message batches.</summary>
+public record MessageBatchesListOptions : BasicListOptions
+{
+    /// <summary>
+    /// Unique identifier of the message stream to filter for.
+    /// </summary>
+    public string? Stream { get; set; }
+
+    /// <inheritdoc/>
+    internal override void Populate(QueryValues values)
+    {
+        base.Populate(values);
+        values.Add("stream", Stream);
+    }
+}

--- a/src/FaluSdk/MessageBatches/MessageBatchesServiceClient.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchesServiceClient.cs
@@ -1,0 +1,105 @@
+﻿using Falu.Core;
+using Tingle.Extensions.JsonPatch;
+
+namespace Falu.MessageBatches;
+
+///
+public class MessageBatchesServiceClient : BaseServiceClient<MessageBatch>,
+                                           ISupportsListing<MessageBatch, MessageBatchesListOptions>,
+                                           ISupportsRetrieving<MessageBatch>,
+                                           ISupportsCreation<MessageBatch, MessageBatchCreateRequest>,
+                                           ISupportsUpdating<MessageBatch, MessageBatchPatchModel>,
+                                           ISupportsCanceling<MessageBatch>,
+                                           ISupportsRedaction<MessageBatch>
+{
+    ///
+    public MessageBatchesServiceClient(HttpClient backChannel, FaluClientOptions options) : base(backChannel, options) { }
+
+    /// <inheritdoc/>
+    protected override string BasePath => "/v1/message_batches";
+
+    /// <summary>List message batches.</summary>
+    /// <inheritdoc/>
+    public virtual Task<ResourceResponse<List<MessageBatch>>> ListAsync(MessageBatchesListOptions? options = null,
+                                                                        RequestOptions? requestOptions = null,
+                                                                        CancellationToken cancellationToken = default)
+    {
+        return ListResourcesAsync(options, requestOptions, cancellationToken);
+    }
+
+    /// <summary>List message batches recursively.</summary>
+    /// <inheritdoc/>
+    public virtual IAsyncEnumerable<MessageBatch> ListRecursivelyAsync(MessageBatchesListOptions? options = null,
+                                                                       RequestOptions? requestOptions = null,
+                                                                       CancellationToken cancellationToken = default)
+    {
+        return ListResourcesRecursivelyAsync(options, requestOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Retrieve a message btach.
+    /// </summary>
+    /// <param name="id">Unique identifier for the message batch.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public virtual Task<ResourceResponse<MessageBatch>> GetAsync(string id,
+                                                                 RequestOptions? options = null,
+                                                                 CancellationToken cancellationToken = default)
+    {
+        return GetResourceAsync(id, options, cancellationToken);
+    }
+
+    /// <summary>Create a message batch.</summary>
+    /// <param name="request"></param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public virtual Task<ResourceResponse<MessageBatch>> CreateAsync(MessageBatchCreateRequest request,
+                                                                    RequestOptions? options = null,
+                                                                    CancellationToken cancellationToken = default)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+        request.Messages?.ForEach(m => m.Template?.Model?.GetType().EnsureAllowedForMessageTemplateModel());
+
+        return CreateResourceAsync<MessageBatch>(request, options, cancellationToken);
+    }
+
+    /// <summary>Update a message batch.</summary>
+    /// <param name="id">Unique identifier for the message batch.</param>
+    /// <param name="patch"></param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public virtual Task<ResourceResponse<MessageBatch>> UpdateAsync(string id,
+                                                                    JsonPatchDocument<MessageBatchPatchModel> patch,
+                                                                    RequestOptions? options = null,
+                                                                    CancellationToken cancellationToken = default)
+    {
+        return UpdateResourceAsync(id, patch, options, cancellationToken);
+    }
+
+    /// <summary>Cancel a message batch preventing further updates.</summary>
+    /// <param name="id">Unique identifier for the message batch.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<ResourceResponse<MessageBatch>> CancelAsync(string id,
+                                                            RequestOptions? options = null,
+                                                            CancellationToken cancellationToken = default)
+    {
+        return CancelResourceAsync(id, options, cancellationToken);
+    }
+
+    /// <summary>Redact a message batch to remove all collected information from Falu.</summary>
+    /// <param name="id">Unique identifier for the message batch.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<ResourceResponse<MessageBatch>> RedactAsync(string id,
+                                                            RequestOptions? options = null,
+                                                            CancellationToken cancellationToken = default)
+    {
+        return RedactResourceAsync(id, options, cancellationToken);
+    }
+}

--- a/src/FaluSdk/Messages/Message.cs
+++ b/src/FaluSdk/Messages/Message.cs
@@ -42,6 +42,15 @@ public class Message : MessagePatchModel, IHasId, IHasCreated, IHasUpdated, IHas
     public string? Stream { get; set; }
 
     /// <summary>
+    /// Number of segments that make up the complete message.
+    /// If the body that is too large to be sent in a single
+    /// message, it is segmented and charged as multiple messages.
+    /// <br/>
+    /// Inbound messages over 160 characters are reassembled when the message is received.
+    /// </summary>
+    public int Segements { get; set; }
+
+    /// <summary>
     /// Provider used for the message.
     /// </summary>
     public MessageProvider? Provider { get; set; }

--- a/src/FaluSdk/Messages/Message.cs
+++ b/src/FaluSdk/Messages/Message.cs
@@ -52,6 +52,11 @@ public class Message : MessagePatchModel, IHasId, IHasCreated, IHasUpdated, IHas
     public MessageSchedule? Schedule { get; set; }
 
     /// <summary>
+    /// Time at which the message was sent.
+    /// </summary>
+    public DateTimeOffset? Sent { get; set; }
+
+    /// <summary>
     /// Time at which the message was delivered.
     /// This is dependent on the underlying provider.
     /// </summary>

--- a/src/FaluSdk/Messages/Message.cs
+++ b/src/FaluSdk/Messages/Message.cs
@@ -42,6 +42,11 @@ public class Message : MessagePatchModel, IHasId, IHasCreated, IHasUpdated, IHas
     public string? Stream { get; set; }
 
     /// <summary>
+    /// Batch that the message belogs to, if any.
+    /// </summary>
+    public string? Batch { get; set; }
+
+    /// <summary>
     /// Number of segments that make up the complete message.
     /// If the body that is too large to be sent in a single
     /// message, it is segmented and charged as multiple messages.

--- a/src/FaluSdk/Messages/MessagesListOptions.cs
+++ b/src/FaluSdk/Messages/MessagesListOptions.cs
@@ -11,6 +11,11 @@ public record MessagesListOptions : BasicListOptions
     public string? Stream { get; set; }
 
     /// <summary>
+    /// Unique identifier of the message batch to filter for.
+    /// </summary>
+    public string? Batch { get; set; }
+
+    /// <summary>
     /// Range filter options for <see cref="Message.Delivered"/> property.
     /// </summary>
     public RangeFilteringOptions<DateTimeOffset>? Delivered { get; set; }
@@ -30,6 +35,7 @@ public record MessagesListOptions : BasicListOptions
     {
         base.Populate(values);
         values.Add("stream", Stream)
+              .Add("batch", Batch)
               .Add("status", Status)
               .Add("delivered", QueryValues.FromRange(Delivered))
               .Add("sent", QueryValues.FromRange(Sent));

--- a/src/FaluSdk/Messages/MessagesListOptions.cs
+++ b/src/FaluSdk/Messages/MessagesListOptions.cs
@@ -11,6 +11,11 @@ public record MessagesListOptions : BasicListOptions
     public RangeFilteringOptions<DateTimeOffset>? Delivered { get; set; }
 
     /// <summary>
+    /// Range filter options for <see cref="Message.Sent"/> property.
+    /// </summary>
+    public RangeFilteringOptions<DateTimeOffset>? Sent { get; set; }
+
+    /// <summary>
     /// Filter options for <see cref="Message.Status"/> property.
     /// </summary>
     public List<string>? Status { get; set; }
@@ -20,6 +25,7 @@ public record MessagesListOptions : BasicListOptions
     {
         base.Populate(values);
         values.Add("status", Status)
-              .Add("delivered", QueryValues.FromRange(Delivered));
+              .Add("delivered", QueryValues.FromRange(Delivered))
+              .Add("sent", QueryValues.FromRange(Sent));
     }
 }

--- a/src/FaluSdk/Messages/MessagesListOptions.cs
+++ b/src/FaluSdk/Messages/MessagesListOptions.cs
@@ -6,6 +6,11 @@ namespace Falu.Messages;
 public record MessagesListOptions : BasicListOptions
 {
     /// <summary>
+    /// Unique identifier of the message stream to filter for.
+    /// </summary>
+    public string? Stream { get; set; }
+
+    /// <summary>
     /// Range filter options for <see cref="Message.Delivered"/> property.
     /// </summary>
     public RangeFilteringOptions<DateTimeOffset>? Delivered { get; set; }
@@ -24,7 +29,8 @@ public record MessagesListOptions : BasicListOptions
     internal override void Populate(QueryValues values)
     {
         base.Populate(values);
-        values.Add("status", Status)
+        values.Add("stream", Stream)
+              .Add("status", Status)
               .Add("delivered", QueryValues.FromRange(Delivered))
               .Add("sent", QueryValues.FromRange(Sent));
     }

--- a/src/FaluSdk/Messages/MessagesServiceClient.cs
+++ b/src/FaluSdk/Messages/MessagesServiceClient.cs
@@ -8,6 +8,7 @@ public class MessagesServiceClient : BaseServiceClient<Message>,
                                      ISupportsListing<Message, MessagesListOptions>,
                                      ISupportsRetrieving<Message>,
                                      ISupportsUpdating<Message, MessagePatchModel>,
+                                     ISupportsCanceling<Message>,
                                      ISupportsRedaction<Message>
 {
     ///
@@ -101,6 +102,19 @@ public class MessagesServiceClient : BaseServiceClient<Message>,
 
         var uri = MakePath("/batch");
         return RequestAsync<MessageCreateResponse>(uri, HttpMethod.Post, messages, options, cancellationToken);
+    }
+
+    /// <summary>Cancel a message preventing further updates.</summary>
+    /// <param name="id">Unique identifier for the message.</param>
+    /// <param name="options">Options to use for the request.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<ResourceResponse<Message>> CancelAsync(string id,
+                                                       RequestOptions? options = null,
+                                                       CancellationToken cancellationToken = default)
+    {
+        var uri = $"{MakeResourcePath(id)}/cancel";
+        return RequestAsync<Message>(uri, HttpMethod.Post, new { }, options, cancellationToken);
     }
 
     /// <summary>Redact a message to remove all collected information from Falu.</summary>

--- a/src/FaluSdk/Messages/MessagesServiceClient.cs
+++ b/src/FaluSdk/Messages/MessagesServiceClient.cs
@@ -113,8 +113,7 @@ public class MessagesServiceClient : BaseServiceClient<Message>,
                                                        RequestOptions? options = null,
                                                        CancellationToken cancellationToken = default)
     {
-        var uri = $"{MakeResourcePath(id)}/cancel";
-        return RequestAsync<Message>(uri, HttpMethod.Post, new { }, options, cancellationToken);
+        return CancelResourceAsync(id, options, cancellationToken);
     }
 
     /// <summary>Redact a message to remove all collected information from Falu.</summary>
@@ -126,7 +125,6 @@ public class MessagesServiceClient : BaseServiceClient<Message>,
                                                        RequestOptions? options = null,
                                                        CancellationToken cancellationToken = default)
     {
-        var uri = $"{MakeResourcePath(id)}/redact";
-        return RequestAsync<Message>(uri, HttpMethod.Post, new { }, options, cancellationToken);
+        return RedactResourceAsync(id, options, cancellationToken);
     }
 }

--- a/src/FaluSdk/Messages/MessagesServiceClient.cs
+++ b/src/FaluSdk/Messages/MessagesServiceClient.cs
@@ -83,6 +83,7 @@ public class MessagesServiceClient : BaseServiceClient<Message>,
     /// <param name="options">Options to use for the request.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    [Obsolete("Migrate to using MessageBatch API resource.")]
     public virtual Task<ResourceResponse<MessageCreateResponse>> SendBatchAsync(IList<MessageCreateRequest> messages,
                                                                                 RequestOptions? options = null,
                                                                                 CancellationToken cancellationToken = default)

--- a/src/FaluSdk/Webhooks/EventTypes.cs
+++ b/src/FaluSdk/Webhooks/EventTypes.cs
@@ -110,6 +110,31 @@ public static class EventTypes
 
     #endregion
 
+    #region Message Batches
+
+    /// <summary>
+    /// Occurs whenever a message batch is sent.
+    /// </summary>
+    public const string MessageBatchCreated = "message_batch.created";
+
+    /// <summary>
+    /// Occurs whenever a message batch is scheduled.
+    /// </summary>
+    public const string MessageBatchScheduled = "message_batch.scheduled";
+
+    /// <summary>
+    /// Occurs whenever the message batch has been cancelled and future
+    /// update attempts have been disabled.
+    /// </summary>
+    public const string MessageBatchCancelled = "message_batch.cancelled";
+
+    /// <summary>
+    /// Occurs whenever a message batch has been redacted.
+    /// </summary>
+    public const string MessageBatchRedacted = "message_batch.redacted";
+
+    #endregion
+
     #region MessageTemplates
 
     /// <summary>

--- a/tests/FaluSdk.Tests/Clients/EvaluationsServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/EvaluationsServiceClientTests.cs
@@ -124,6 +124,34 @@ public class EvaluationsServiceClientTests : BaseServiceClientTests<Evaluation>
 
     [Theory]
     [MemberData(nameof(RequestOptionsData))]
+    public async Task CancelAsync_Works(RequestOptions options)
+    {
+        var handler = new DynamicHttpMessageHandler((req, ct) =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{BasePath}/{Data!.Id}/cancel", req.RequestUri!.AbsolutePath);
+
+            AssertRequestHeaders(req, options);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json),
+            };
+
+            return response;
+        });
+
+        await TestAsync(handler, async (client) =>
+        {
+            var response = await client.Evaluations.CancelAsync(Data!.Id!, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
     public async Task RedactAsync_Works(RequestOptions options)
     {
         var handler = new DynamicHttpMessageHandler((req, ct) =>

--- a/tests/FaluSdk.Tests/Clients/IdentityVerificationsServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/IdentityVerificationsServiceClientTests.cs
@@ -123,6 +123,34 @@ public class IdentityVerificationsServiceClientTests : BaseServiceClientTests<Id
 
     [Theory]
     [MemberData(nameof(RequestOptionsData))]
+    public async Task CancelAsync_Works(RequestOptions options)
+    {
+        var handler = new DynamicHttpMessageHandler((req, ct) =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{BasePath}/{Data!.Id}/cancel", req.RequestUri!.AbsolutePath);
+
+            AssertRequestHeaders(req, options);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json),
+            };
+
+            return response;
+        });
+
+        await TestAsync(handler, async (client) =>
+        {
+            var response = await client.IdentityVerifications.CancelAsync(Data!.Id!, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
     public async Task RedactAsync_Works(RequestOptions options)
     {
         var handler = new DynamicHttpMessageHandler((req, ct) =>

--- a/tests/FaluSdk.Tests/Clients/MessageBatchesServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessageBatchesServiceClientTests.cs
@@ -1,0 +1,188 @@
+﻿using Falu.Core;
+using Falu.MessageBatches;
+using System.Net;
+using System.Net.Mime;
+using System.Text;
+using Tingle.Extensions.JsonPatch;
+using Xunit;
+
+namespace Falu.Tests.Clients;
+
+public class MessageBatchesServiceClientTests : BaseServiceClientTests<MessageBatch>
+{
+    public MessageBatchesServiceClientTests() : base(new()
+    {
+        Id = "msba_123",
+        Messages = new List<string> { "msg_123", },
+        Created = DateTimeOffset.UtcNow,
+        Updated = DateTimeOffset.UtcNow,
+    }, "/v1/message_batches")
+    { }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
+    public async Task GetAsync_Works(RequestOptions options)
+    {
+        var handler = GetAsync_Handler(options);
+
+        await TestAsync(handler, async (client) =>
+        {
+            var response = await client.MessageBatches.GetAsync(Data!.Id!, options);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+            Assert.Equal(Data!.Id, response.Resource!.Id);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsWithHasContinuationTokenData))]
+    public async Task ListAsync_Works(RequestOptions options, bool hasContinuationToken)
+    {
+        var handler = ListAsync_Handler(hasContinuationToken, options);
+
+        await TestAsync(handler, async (client) =>
+        {
+            var opt = new MessageBatchesListOptions
+            {
+                Count = 1
+            };
+
+            var response = await client.MessageBatches.ListAsync(opt, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+            Assert.Single(response.Resource);
+
+            if (hasContinuationToken) Assert.NotNull(response.ContinuationToken);
+            else Assert.Null(response.ContinuationToken);
+
+            var msgstr = response!.Resource!.Single();
+            Assert.Equal(Data!.Id!, msgstr.Id);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
+    public async Task ListRecursivelyAsync_Works(RequestOptions options)
+    {
+        var handler = ListAsync_Handler(options: options);
+
+        await TestAsync(handler, async (client) =>
+        {
+            var opt = new MessageBatchesListOptions
+            {
+                Count = 1
+            };
+
+            var results = new List<MessageBatch>();
+            await foreach (var item in client.MessageBatches.ListRecursivelyAsync(opt, options))
+            {
+                results.Add(item);
+            }
+
+            Assert.Single(results);
+            var ev = results.Single();
+            Assert.Equal(Data!.Id, ev.Id);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
+    public async Task CreateAsync_Works(RequestOptions options)
+    {
+        var handler = CreateAsync_Handler(options);
+
+        await TestAsync(handler, async (client) =>
+        {
+            var model = new MessageBatchCreateRequest
+            {
+                Messages = new List<MessageBatchCreateRequestMessage>
+                {
+                    new MessageBatchCreateRequestMessage
+                    {
+                        To = new[] { "+254722000000", },
+                        Body = "This is a test",
+                    },
+                },
+            };
+            var response = await client.MessageBatches.CreateAsync(model, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
+    public async Task UpdateAsync_Works(RequestOptions options)
+    {
+        var handler = UpdateAsync_Handler(options);
+
+        await TestAsync(handler, async (client) =>
+        {
+            var document = new JsonPatchDocument<MessageBatchPatchModel>();
+            document.Replace(x => x.Metadata, new Dictionary<string, string> { ["purpose"] = "loan-repayment" });
+
+            var response = await client.MessageBatches.UpdateAsync(Data!.Id!, document, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
+    public async Task CancelAsync_Works(RequestOptions options)
+    {
+        var handler = new DynamicHttpMessageHandler((req, ct) =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{BasePath}/{Data!.Id}/cancel", req.RequestUri!.AbsolutePath);
+
+            AssertRequestHeaders(req, options);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json),
+            };
+
+            return response;
+        });
+
+        await TestAsync(handler, async (client) =>
+        {
+            var response = await client.MessageBatches.CancelAsync(Data!.Id!, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
+    public async Task RedactAsync_Works(RequestOptions options)
+    {
+        var handler = new DynamicHttpMessageHandler((req, ct) =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{BasePath}/{Data!.Id}/redact", req.RequestUri!.AbsolutePath);
+
+            AssertRequestHeaders(req, options);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json),
+            };
+
+            return response;
+        });
+
+        await TestAsync(handler, async (client) =>
+        {
+            var response = await client.MessageBatches.RedactAsync(Data!.Id!, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+}

--- a/tests/FaluSdk.Tests/Clients/MessagesServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessagesServiceClientTests.cs
@@ -144,11 +144,13 @@ public class MessagesServiceClientTests : BaseServiceClientTests<Message>
                 Body = Data!.Body
             };
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var response = await client.Messages.SendBatchAsync(new[] { model }, options);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.NotNull(response.Resource);
-            Assert.Single(response.Resource!.Ids);
+            Assert.NotNull(response.Resource?.Ids);
+            Assert.Single(response.Resource.Ids);
         });
     }
 

--- a/tests/FaluSdk.Tests/Clients/MessagesServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessagesServiceClientTests.cs
@@ -172,6 +172,34 @@ public class MessagesServiceClientTests : BaseServiceClientTests<Message>
 
     [Theory]
     [MemberData(nameof(RequestOptionsData))]
+    public async Task CancelAsync_Works(RequestOptions options)
+    {
+        var handler = new DynamicHttpMessageHandler((req, ct) =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal($"{BasePath}/{Data!.Id}/cancel", req.RequestUri!.AbsolutePath);
+
+            AssertRequestHeaders(req, options);
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json),
+            };
+
+            return response;
+        });
+
+        await TestAsync(handler, async (client) =>
+        {
+            var response = await client.Messages.CancelAsync(Data!.Id!, options);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Resource);
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestOptionsData))]
     public async Task RedactAsync_Works(RequestOptions options)
     {
         var handler = new DynamicHttpMessageHandler((req, ct) =>


### PR DESCRIPTION
- Added support for message batches API hence mark `SendBatchAsync(...)` as obsolete in its favour.
- Added endpoints/methods for cancel and redact on identity verifications, evaluations and messages.
- Added `Batch`, `Segements`, `Sent` properties to `Message`.
- Added filters by `sent`, `batch`, and `stream ` when listing messages
