### PR TITLE
API Updates for Version 2022-09-01

### DIFF
--- a/src/FaluSdk/FaluClientOptions.cs
+++ b/src/FaluSdk/FaluClientOptions.cs
@@ -11,7 +11,7 @@ public class FaluClientOptions
     private static JsonSerializerOptions? serializerOptions;
 
     /// <summary>The ApiVersion that the SDK conforms to.</summary>
-    internal const string ApiVersion = "2022-05-01";
+    internal const string ApiVersion = "2022-09-01";
 
     /// <summary>Serialization options.</summary>
     internal JsonSerializerOptions SerializerOptions { get; } = GetSerializerOptions();

--- a/src/FaluSdk/MessageBatches/MessageBatchSchedule.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchSchedule.cs
@@ -11,7 +11,7 @@ public class MessageBatchSchedule
     public DateTimeOffset Time { get; set; }
 
     /// <summary>
-    /// Duration for which the message batch is/was to be delayed before sending.
+    /// ISO8601 duration for which the message batch is/was to be delayed before sending.
     /// </summary>
-    public TimeSpan? Delay { get; set; }
+    public string? Delay { get; set; }
 }

--- a/src/FaluSdk/Messages/MessageCreateRequest.cs
+++ b/src/FaluSdk/Messages/MessageCreateRequest.cs
@@ -9,7 +9,7 @@ public class MessageCreateRequest : MessagePatchModel
     /// Destination phone numbers in <see href="https://en.wikipedia.org/wiki/E.164">E.164 format</see>.
     /// You can provide up to 500 numbers in one request.
     /// </summary>
-    public IList<string>? To { get; set; }
+    public string? To { get; set; }
 
     /// <summary>
     /// Actual message content to be sent.

--- a/src/FaluSdk/Messages/MessageCreateRequestSchedule.cs
+++ b/src/FaluSdk/Messages/MessageCreateRequestSchedule.cs
@@ -13,13 +13,13 @@ public class MessageCreateRequestSchedule
     public DateTimeOffset? Time { get; set; }
 
     /// <summary>
-    /// Duration for which the message was be delayed before sending,
-    /// relative to the current server time.
+    /// ISO8601 duration for which the message should be delayed
+    /// before sending, relative to the current server time.
     /// Between 5 minutes and 30 days.
     /// Required if <see cref="Time"/> is not specified.
     /// </summary>
-    /// <example>1.06:00:00</example>
-    public TimeSpan? Delay { get; set; }
+    /// <example>PT15M</example>
+    public string? Delay { get; set; }
 
     /// <summary>
     /// Convert a <see cref="DateTimeOffset"/> to a <see cref="MessageCreateRequestSchedule"/>.
@@ -28,8 +28,8 @@ public class MessageCreateRequestSchedule
     public static implicit operator MessageCreateRequestSchedule(DateTimeOffset time) => new() { Time = time, };
 
     /// <summary>
-    /// Convert a <see cref="TimeSpan"/> to a <see cref="MessageCreateRequestSchedule"/>.
+    /// Convert a <see cref="string"/> to a <see cref="MessageCreateRequestSchedule"/>.
     /// </summary>
     /// <param name="delay">Value for <see cref="Delay"/></param>
-    public static implicit operator MessageCreateRequestSchedule(TimeSpan delay) => new() { Delay = delay, };
+    public static implicit operator MessageCreateRequestSchedule(string delay) => new() { Delay = delay, };
 }

--- a/src/FaluSdk/Messages/MessageSchedule.cs
+++ b/src/FaluSdk/Messages/MessageSchedule.cs
@@ -11,7 +11,7 @@ public class MessageSchedule
     public DateTimeOffset Time { get; set; }
 
     /// <summary>
-    /// Duration for which the message is/was be delayed before sending.
+    /// ISO8601 duration for which the message is/was be delayed before sending.
     /// </summary>
-    public TimeSpan? Delay { get; set; }
+    public string? Delay { get; set; }
 }

--- a/tests/FaluSdk.Tests/Clients/MessagesServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessagesServiceClientTests.cs
@@ -100,7 +100,7 @@ public class MessagesServiceClientTests : BaseServiceClientTests<Message>
         {
             var model = new MessageCreateRequest
             {
-                To = new[] { Data!.To!, },
+                To = Data!.To!,
                 Body = Data!.Body
             };
             var response = await client.Messages.CreateAsync(model, options);


### PR DESCRIPTION
- Update API version to `2022-09-01`.
- `To` in `MessageCreateRequest` now takes one destination only.
- Replace `TimeSpan` in models with `string` for ISO8601 duration.

