### PR TITLE
Basic SDK updates

### DIFF
--- a/src/FaluSdk/Core/QueryValues.cs
+++ b/src/FaluSdk/Core/QueryValues.cs
@@ -177,7 +177,7 @@ public sealed class QueryValues : ICollection<KeyValuePair<string, StringValues>
         => ((ICollection<KeyValuePair<string, StringValues>>)values).CopyTo(array, arrayIndex);
 
     /// <inheritdoc/>
-    bool ICollection<KeyValuePair<string, StringValues>>.Remove(KeyValuePair<string, StringValues> item) 
+    bool ICollection<KeyValuePair<string, StringValues>>.Remove(KeyValuePair<string, StringValues> item)
         => ((ICollection<KeyValuePair<string, StringValues>>)values).Remove(item);
 
     #endregion

--- a/src/FaluSdk/MessageBatches/MessageBatchCreateRequest.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchCreateRequest.cs
@@ -9,6 +9,7 @@ public class MessageBatchCreateRequest
 {
     /// <summary>
     /// The messages.
+    /// You can send up to 1,000 messages in one API request.
     /// </summary>
     public List<MessageBatchCreateRequestMessage>? Messages { get; set; }
 

--- a/src/FaluSdk/MessageBatches/MessageBatchCreateRequestMessage.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchCreateRequestMessage.cs
@@ -9,7 +9,7 @@ public class MessageBatchCreateRequestMessage
 {
     /// <summary>
     /// Destination phone numbers in <see href="https://en.wikipedia.org/wiki/E.164">E.164 format</see>.
-    /// You can provide up to 500 numbers in one request.
+    /// You can send up to 1,000 messages in one API request.
     /// </summary>
     public IList<string>? Tos { get; set; }
 

--- a/src/FaluSdk/MessageBatches/MessageBatchesServiceClient.cs
+++ b/src/FaluSdk/MessageBatches/MessageBatchesServiceClient.cs
@@ -55,6 +55,7 @@ public class MessageBatchesServiceClient : BaseServiceClient<MessageBatch>,
     /// <param name="options">Options to use for the request.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    /// <remarks>You can send up to 1,000 messages in one API request.</remarks>
     public virtual Task<ResourceResponse<MessageBatch>> CreateAsync(MessageBatchCreateRequest request,
                                                                     RequestOptions? options = null,
                                                                     CancellationToken cancellationToken = default)

--- a/src/FaluSdk/MessageTemplates/MessageTemplatesListOptions.cs
+++ b/src/FaluSdk/MessageTemplates/MessageTemplatesListOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Falu.MessageTemplates;
 
-/// <summary>Options for filtering and pagination of message tempaltes.</summary>
+/// <summary>Options for filtering and pagination of message templates.</summary>
 public record MessageTemplatesListOptions : BasicListOptions
 {
     // intentionally left blank

--- a/src/FaluSdk/Messages/MessageCreateRequest.cs
+++ b/src/FaluSdk/Messages/MessageCreateRequest.cs
@@ -6,8 +6,7 @@
 public class MessageCreateRequest : MessagePatchModel
 {
     /// <summary>
-    /// Destination phone numbers in <see href="https://en.wikipedia.org/wiki/E.164">E.164 format</see>.
-    /// You can provide up to 500 numbers in one request.
+    /// Destination phone number in <see href="https://en.wikipedia.org/wiki/E.164">E.164 format</see>.
     /// </summary>
     public string? To { get; set; }
 

--- a/tests/FaluSdk.Tests/Clients/CustomersServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/CustomersServiceClientTests.cs
@@ -84,8 +84,8 @@ public class CustomersServiceClientTests : BaseServiceClientTests<Customer>
             }
 
             Assert.Single(results);
-            var msgtmpl = results.Single();
-            Assert.Equal(Data!.Id, msgtmpl.Id);
+            var cst = results.Single();
+            Assert.Equal(Data!.Id, cst.Id);
         });
     }
 

--- a/tests/FaluSdk.Tests/Clients/MessageBatchesServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessageBatchesServiceClientTests.cs
@@ -149,7 +149,7 @@ public class MessageBatchesServiceClientTests : BaseServiceClientTests<MessageBa
 
         await TestAsync(handler, async (client) =>
         {
-            var response = await client.MessageBatches.StatusAsync(Data!.Id!);
+            var response = await client.MessageBatches.StatusAsync(Data!.Id!, options);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(response.Resource);

--- a/tests/FaluSdk.Tests/Clients/MessageSuppressionsServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessageSuppressionsServiceClientTests.cs
@@ -83,8 +83,8 @@ public class MessageSuppressionsServiceClientTests : BaseServiceClientTests<Mess
             }
 
             Assert.Single(results);
-            var msgtmpl = results.Single();
-            Assert.Equal(Data!.Id, msgtmpl.Id);
+            var sup = results.Single();
+            Assert.Equal(Data!.Id, sup.Id);
         });
     }
 

--- a/tests/FaluSdk.Tests/Clients/MessageTemplatesServiceClientTests.cs
+++ b/tests/FaluSdk.Tests/Clients/MessageTemplatesServiceClientTests.cs
@@ -13,7 +13,7 @@ public class MessageTemplatesServiceClientTests : BaseServiceClientTests<Message
 {
     public MessageTemplatesServiceClientTests() : base(new()
     {
-        Id = "tmpl_123",
+        Id = "mtpl_123",
         Alias = "loyalty",
         Body = "Hi {{name}}! Thanks for being a loyal customer. We appreciate you!",
         Created = DateTimeOffset.UtcNow,
@@ -85,8 +85,8 @@ public class MessageTemplatesServiceClientTests : BaseServiceClientTests<Message
             }
 
             Assert.Single(results);
-            var msgtmpl = results.Single();
-            Assert.Equal(Data!.Id, msgtmpl.Id);
+            var mtpl = results.Single();
+            Assert.Equal(Data!.Id, mtpl.Id);
         });
     }
 


### PR DESCRIPTION
- Remove whitespaces and fix some typos.
- Added comments regarding the maximum number of messages in one API call
- Update XML comment on `MessageCreateRequest.To`.
- Unit test for `StatusAsync(...)` should make use of supplied options.
- Update example for message template identifier.