### PR TITLE
Updates to MessageTemplateModel logic

### DIFF
--- a/src/FaluSdk/MessageTemplates/MessageTemplateModel.cs
+++ b/src/FaluSdk/MessageTemplates/MessageTemplateModel.cs
@@ -74,8 +74,7 @@ public readonly struct MessageTemplateModel : IEquatable<MessageTemplateModel>
         if (model is null) throw new ArgumentNullException(nameof(model));
         EnsureAllowedModelType(model);
 
-        var node = JsonSerializer.SerializeToNode(value: model, options: options);
-        return new MessageTemplateModel(Create(node));
+        return Create(JsonSerializer.SerializeToNode(value: model, options: options));
     }
 
     /// <summary>Create a <see cref="MessageTemplateModel"/> from another model object type.</summary>
@@ -97,8 +96,7 @@ public readonly struct MessageTemplateModel : IEquatable<MessageTemplateModel>
         if (model is null) throw new ArgumentNullException(nameof(model));
         EnsureAllowedModelType(model);
 
-        var node = JsonSerializer.SerializeToNode(value: model, jsonTypeInfo: jsonTypeInfo);
-        return new MessageTemplateModel(Create(node));
+        return Create(JsonSerializer.SerializeToNode(value: model, jsonTypeInfo: jsonTypeInfo));
     }
 
     /// <summary>Create a <see cref="MessageTemplateModel"/> from another model object type.</summary>
@@ -129,8 +127,7 @@ public readonly struct MessageTemplateModel : IEquatable<MessageTemplateModel>
         if (model is null) throw new ArgumentNullException(nameof(model));
         EnsureAllowedModelType(model);
 
-        var node = JsonSerializer.SerializeToNode(value: model, inputType: inputType, context: context);
-        return new MessageTemplateModel(Create(node));
+        return Create(JsonSerializer.SerializeToNode(value: model, inputType: inputType, context: context));
     }
 
     /// <param name="node"></param>

--- a/src/FaluSdk/MessageTemplates/MessageTemplateModel.cs
+++ b/src/FaluSdk/MessageTemplates/MessageTemplateModel.cs
@@ -13,6 +13,11 @@ namespace Falu.MessageTemplates;
 [JsonConverter(typeof(Serialization.MessageTemplateModelJsonConverter))]
 public readonly struct MessageTemplateModel : IEquatable<MessageTemplateModel>
 {
+    /// <summary>
+    /// An empty template model that does not require serialization
+    /// </summary>
+    public static readonly MessageTemplateModel Empty = new(new());
+
     private readonly JsonObject @object;
 
     /// <summary>Creates an instance of <see cref="MessageTemplateModel"/>.</summary>

--- a/tests/FaluSdk.Tests/MessageTemplateModelTests.cs
+++ b/tests/FaluSdk.Tests/MessageTemplateModelTests.cs
@@ -1,10 +1,45 @@
 ﻿using Falu.MessageTemplates;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
+using SC = Falu.Serialization.FaluSerializerContext;
 
 namespace Falu.Tests;
 
 public class MessageTemplateModelTests
 {
+    [Fact]
+    [RequiresUnreferencedCode(MessageStrings.SerializationUnreferencedCodeMessage)]
+    [RequiresDynamicCode(MessageStrings.SerializationRequiresDynamicCodeMessage)]
+    public void RoundTrip_Works_For_JsonSerializerOptions()
+    {
+        var so = SC.Default.Options;
+        var original = new Dictionary<string, string> { ["name"] = "cake" };
+        var model = MessageTemplateModel.Create(original, so);
+        var reconverted = model.ConvertTo<Dictionary<string, string>>(so);
+        Assert.False(ReferenceEquals(reconverted, original)); // different instances
+        Assert.Equal(original, reconverted); // same content
+    }
+
+    [Fact]
+    public void RoundTrip_Works_For_JsonTypeInfo()
+    {
+        var original = new Dictionary<string, string> { ["name"] = "cake" };
+        var model = MessageTemplateModel.Create(original, SC.Default.DictionaryStringString);
+        var reconverted = model.ConvertTo(SC.Default.DictionaryStringString);
+        Assert.False(ReferenceEquals(reconverted, original)); // different instances
+        Assert.Equal(original, reconverted); // same content
+    }
+
+    [Fact]
+    public void RoundTrip_Works_For_JsonSerializerContext()
+    {
+        var original = new Dictionary<string, string> { ["name"] = "cake" };
+        var model = MessageTemplateModel.Create(original, typeof(Dictionary<string, string>), SC.Default);
+        var reconverted = model.ConvertTo(typeof(Dictionary<string, string>), SC.Default);
+        Assert.False(ReferenceEquals(reconverted, original)); // different instances
+        Assert.Equal(original, reconverted); // same content
+    }
+
     [Theory]
     [InlineData(typeof(TestEnum), false)]
     [InlineData(typeof(string), false)]


### PR DESCRIPTION
- Reduce double allocations of template model during creation
- Added `Empty` property to reduce allocations of `MessageTemplateModel` in practical usage
- Added methods to convert a template to another object
- Test all conversion methods in `MessageTemplateModel`


